### PR TITLE
Fix container build and dns entries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN go mod tidy && make test-bin
 
 FROM centos:7
 COPY --from=builder /usr/src/github.com/redhat-eets/sno-tests/bin/ptptests /usr/bin/ptptests
-CMD ["/usr/bin/ptptests", "-test.v"]
+COPY hack/runtest-in-pod.sh /usr/bin/runtest-in-pod.sh
+CMD ["/usr/bin/runtest-in-pod.sh"]

--- a/hack/build-test-bin.sh
+++ b/hack/build-test-bin.sh
@@ -23,8 +23,8 @@ mkdir -p bin
 function build_and_move_suite {
 	suite=$1
 	target=$2
-	ginkgo build ./"$suite"
-	mv ./"$suite"/"$suite".test "$target"
+	ginkgo build ./test/"$suite"
+	mv ./test/"$suite"/"$suite".test "$target"
 }
 
 build_and_move_suite "ptp" "./bin/ptptests"

--- a/hack/runtest-in-pod.sh
+++ b/hack/runtest-in-pod.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cat ${CFG_DIR:-/testconfig}/dns-entries >> /etc/hosts
+
+ptptests -test.v
+
+

--- a/manifests/pod-sno-tests.yaml
+++ b/manifests/pod-sno-tests.yaml
@@ -9,9 +9,6 @@ spec:
   containers:
   - name: sno-tests 
     image: 192.168.49.147:5000/ptp-test:latest
-    command:
-      - ptptests 
-      - "-test.v"
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
Fix container build issue due to the addition of the test folder.
Add runtest-in-pod.sh to allow test run from an OCP pod.