### PR TITLE
Fix single T-GM SNO test run issue

### DIFF
--- a/test/ptp/ptp_suite_test.go
+++ b/test/ptp/ptp_suite_test.go
@@ -77,6 +77,12 @@ var _ = BeforeSuite(func() {
 	}
 
 	for _, role := range roles {
+		if _, ok := info[role]; !ok {
+			clients[role] = nil
+			nodenames[role] = ""
+			continue
+		}
+
 		if len(info[role]) > 1 {
 			nodenames[role] = info[role][1]
 		} else {


### PR DESCRIPTION
We should allow a single T-GM SNO test run to check the GNSS