### PR TITLE
T-GM tests: Validate the signal coming from the GNSS

### DIFF
--- a/test/pkg/consts/const.go
+++ b/test/pkg/consts/const.go
@@ -7,4 +7,8 @@ const (
 	WPCDeviceType = "E810-XXV-4T"
 	// ICEDriverFirmwareVerMinVersion is the minimal ICE driver version required for WPC NIC
 	ICEDriverFirmwareVerMinVersion = 4.01
+	// DPLLLockedHOACQState is the required DPLL state -> 3: DPLL Locked Holdover Acquired
+	DPLLLockedHOACQState = "3"
+	// DPLLMaxAbsOffset is the maximum absolute DPLL offset in nanoseconds
+	DPLLMaxAbsOffset = 30
 )


### PR DESCRIPTION
Add a test to verify that a valid 1PPS signal coming from the GNSS receiver arrives at the DPLL of the WPC card.
