### PR TITLE
Enable staticcheck linter and make it pass

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,8 +29,8 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: -D staticcheck -v --timeout 5m
+          args: -v --timeout 5m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 

--- a/test/pkg/k8sreporter/reporter.go
+++ b/test/pkg/k8sreporter/reporter.go
@@ -66,6 +66,7 @@ func New(kubeconfig, path, namespace string) *KubernetesReporter {
 // dumpSubpath is the subpath relative to reportPath where the reporter will
 // dump the output.
 func (r *KubernetesReporter) Dump(duration time.Duration, testName string) {
+	// nolint:staticcheck
 	dumpSubpath := strings.Replace(ginkgo.CurrentGinkgoTestDescription().TestText, " ", "-", -1)
 
 	since := time.Now().Add(-duration).Add(-5 * time.Second)
@@ -101,7 +102,7 @@ func (r *KubernetesReporter) logPods(dirName string) {
 			return
 		}
 		defer f.Close()
-		fmt.Fprintf(f, fileSeparator)
+		fmt.Fprint(f, fileSeparator)
 		j, err := json.MarshalIndent(pod, "", "    ")
 		if err != nil {
 			fmt.Println("Failed to marshal pods", err)
@@ -119,7 +120,7 @@ func (r *KubernetesReporter) logNodes(dirName string) {
 		return
 	}
 	defer f.Close()
-	fmt.Fprintf(f, fileSeparator)
+	fmt.Fprint(f, fileSeparator)
 
 	nodes, err := r.clients.Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -159,7 +160,7 @@ func (r *KubernetesReporter) logLogs(since time.Time, dirName string) {
 			logStart := metav1.NewTime(since)
 			logs, err := r.clients.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name, SinceTime: &logStart}).DoRaw(context.Background())
 			if err == nil {
-				fmt.Fprintf(f, fileSeparator)
+				fmt.Fprint(f, fileSeparator)
 				fmt.Fprintf(f, "Dumping logs for pod %s-%s-%s\n", pod.Namespace, pod.Name, container.Name)
 				fmt.Fprintln(f, string(logs))
 			}
@@ -176,7 +177,7 @@ func (r *KubernetesReporter) logCustomCR(cr runtimeclient.ObjectList, namespace 
 		return
 	}
 	defer f.Close()
-	fmt.Fprintf(f, fileSeparator)
+	fmt.Fprint(f, fileSeparator)
 	if namespace != nil {
 		fmt.Fprintf(f, "Dumping %T in namespace %s\n", cr, *namespace)
 	} else {


### PR DESCRIPTION
Current set of linters in golangci-lint has staticcheck disabled. If we enable it, there is a couple of errors:
[akiselev@akiselev-x1c sno-tests]$ golangci-lint run 
test/pkg/pods/pods.go:201:35: SA1019: pointer.Int64Ptr is deprecated: Use Int64 instead. (staticcheck)
                        TerminationGracePeriodSeconds: pointer.Int64Ptr(0),
                                                       ^
test/pkg/pods/pods.go:225:33: SA1019: pointer.BoolPtr is deprecated: Use Bool instead. (staticcheck)
        c.SecurityContext.Privileged = pointer.BoolPtr(true)
                                       ^
[akiselev@akiselev-x1c sno-tests]$ 

This PR enables staticcheck and makes proposed pointer types re-factoring.